### PR TITLE
feat: session persistence hardening (R9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,11 @@ excalidraw.log
 # Marketing content (not for GitHub)
 marketing/
 
-# Internal development process (Spec Kit governance — not part of PDLC product)
+# Internal development process (Spec Kit + Loki — not part of PDLC product)
 .claude/commands/speckit.*.md
 .claude/product-context.md
 .specify/
 specs/
 docs/plans/
+openspec/
+.loki/

--- a/hooks/lib/pdlc-director.sh
+++ b/hooks/lib/pdlc-director.sh
@@ -27,6 +27,9 @@ fi
 if ! declare -f pdlc_test_strategy &>/dev/null; then
   source "${DIRECTOR_LIB_DIR}/pdlc-test-strategy.sh"
 fi
+if ! declare -f pdlc_session_restore &>/dev/null; then
+  source "${DIRECTOR_LIB_DIR}/pdlc-session.sh"
+fi
 
 # Valid Director actions
 PDLC_DIRECTOR_ACTIONS=(specify plan generate-tasks implement review archive)
@@ -130,6 +133,9 @@ $(pdlc_director_architecture_context "${DIRECTOR_LIB_DIR}/../.." 2>/dev/null || 
 
 ## Test Strategy
 $(pdlc_test_strategy "$spec_dir" 2>/dev/null || echo "Test strategy unavailable")
+
+## Previous Session Context
+$(pdlc_session_restore 2>/dev/null || echo "No previous session checkpoint")
 
 ## Dispatch Heuristics (guidance, not rules)
 - Phases before Implementing (specify, plan, generate-tasks) are typically same-session

--- a/hooks/lib/pdlc-session.sh
+++ b/hooks/lib/pdlc-session.sh
@@ -25,23 +25,21 @@ fi
 # with the current iteration's state. Uses pdlc_write_handoff for atomic
 # tmp+mv writes.
 #
-# Usage: pdlc_session_save <spec_dir> <iteration> <lifecycle_state> \
+# Usage: pdlc_session_save <iteration> <lifecycle_state> \
 #            <director_decision> <actor_result> <critic_verdict>
 #
 # Arguments:
-#   spec_dir          — path to the spec directory
 #   iteration         — current iteration number (integer)
 #   lifecycle_state   — inferred lifecycle state (e.g., Implementing)
 #   director_decision — "action|mode|rationale" string
 #   actor_result      — summary of Actor outcome
 #   critic_verdict    — accept, retry, or escalate
 pdlc_session_save() {
-  local spec_dir="$1"
-  local iteration="$2"
-  local lifecycle_state="$3"
-  local director_decision="$4"
-  local actor_result="$5"
-  local critic_verdict="$6"
+  local iteration="$1"
+  local lifecycle_state="$2"
+  local director_decision="$3"
+  local actor_result="$4"
+  local critic_verdict="$5"
 
   if [[ ! -f "${PDLC_HANDOFF}" ]]; then
     return 0

--- a/hooks/lib/pdlc-session.sh
+++ b/hooks/lib/pdlc-session.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# hooks/lib/pdlc-session.sh — PDLC session persistence library
+#
+# Provides checkpoint save/restore for crash-resilient session recovery.
+# Persists Director dispatch decisions, quality gate results, and iteration
+# state to the HANDOFF.md body section.
+#
+# Two public functions:
+#   pdlc_session_save  — writes checkpoint to HANDOFF.md body (atomic)
+#   pdlc_session_restore — reads checkpoint from HANDOFF.md body
+#
+# Depends on: pdlc-state.sh (must be sourced first)
+
+set -euo pipefail
+
+# Source state library if not already loaded
+if ! declare -f pdlc_get_field &>/dev/null; then
+  PDLC_SESSION_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  source "${PDLC_SESSION_LIB_DIR}/pdlc-state.sh"
+fi
+
+# Save session checkpoint to HANDOFF.md body section (atomic write).
+#
+# Appends/replaces a "### Session Checkpoint" section in the HANDOFF.md body
+# with the current iteration's state. Uses pdlc_write_handoff for atomic
+# tmp+mv writes.
+#
+# Usage: pdlc_session_save <spec_dir> <iteration> <lifecycle_state> \
+#            <director_decision> <actor_result> <critic_verdict>
+#
+# Arguments:
+#   spec_dir          — path to the spec directory
+#   iteration         — current iteration number (integer)
+#   lifecycle_state   — inferred lifecycle state (e.g., Implementing)
+#   director_decision — "action|mode|rationale" string
+#   actor_result      — summary of Actor outcome
+#   critic_verdict    — accept, retry, or escalate
+pdlc_session_save() {
+  local spec_dir="$1"
+  local iteration="$2"
+  local lifecycle_state="$3"
+  local director_decision="$4"
+  local actor_result="$5"
+  local critic_verdict="$6"
+
+  if [[ ! -f "${PDLC_HANDOFF}" ]]; then
+    return 0
+  fi
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  # Build quality line from frontmatter critic fields
+  local batch quality_line
+  batch=$(pdlc_get_field "batch")
+  batch="${batch:-1}"
+  local advocate skeptic
+  advocate=$(pdlc_get_field "batch_${batch}_advocate")
+  skeptic=$(pdlc_get_field "batch_${batch}_skeptic")
+  if [[ -n "$advocate" || -n "$skeptic" ]]; then
+    quality_line="advocate=${advocate:-N/A}, skeptic=${skeptic:-N/A}"
+  else
+    quality_line="N/A"
+  fi
+
+  local checkpoint_block
+  checkpoint_block="### Session Checkpoint
+
+- Iteration: ${iteration}
+- Lifecycle: ${lifecycle_state}
+- Director: ${director_decision}
+- Actor: ${actor_result}
+- Critic: ${critic_verdict}
+- Quality: ${quality_line}
+- Timestamp: ${timestamp}"
+
+  # Extract frontmatter (without --- delimiters)
+  local frontmatter
+  frontmatter=$(awk '
+    BEGIN { in_fm=0 }
+    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+    in_fm && /^---[[:space:]]*$/ { exit }
+    in_fm { print }
+  ' "${PDLC_HANDOFF}")
+
+  # Extract body (everything after second ---)
+  local body
+  body=$(awk '
+    BEGIN { in_fm=0; past=0 }
+    NR==1 && /^---[[:space:]]*$/ { in_fm=1; next }
+    in_fm && /^---[[:space:]]*$/ { past=1; next }
+    past { print }
+  ' "${PDLC_HANDOFF}")
+
+  # Remove existing checkpoint section from body
+  local cleaned_body
+  cleaned_body=$(printf '%s\n' "$body" | awk '
+    /^### Session Checkpoint/ { skip=1; next }
+    skip && /^###? / { skip=0 }
+    !skip { print }
+  ')
+
+  # Trim trailing blank lines from cleaned body (awk for macOS compat)
+  cleaned_body=$(printf '%s\n' "$cleaned_body" | awk '
+    { lines[NR] = $0; last = NR }
+    END {
+      while (last > 0 && lines[last] ~ /^[[:space:]]*$/) last--
+      for (i = 1; i <= last; i++) print lines[i]
+    }
+  ')
+
+  # Build new body: cleaned body + checkpoint block
+  local new_body
+  if [[ -n "$cleaned_body" ]]; then
+    new_body="${cleaned_body}
+
+${checkpoint_block}"
+  else
+    new_body="${checkpoint_block}"
+  fi
+
+  # Atomic write via pdlc_write_handoff
+  pdlc_write_handoff "$frontmatter" "$new_body"
+}
+
+# Restore session checkpoint from HANDOFF.md body section.
+#
+# Reads the "### Session Checkpoint" section and outputs the checkpoint
+# fields as key-value lines suitable for inclusion in Director prompts.
+#
+# Usage: pdlc_session_restore
+# Output: checkpoint lines (one per line, "- Key: value" format) or empty
+# Returns: 0 always
+pdlc_session_restore() {
+  if [[ ! -f "${PDLC_HANDOFF}" ]]; then
+    echo ""
+    return 0
+  fi
+
+  # Extract lines between "### Session Checkpoint" and next heading (or EOF)
+  awk '
+    /^### Session Checkpoint/ { found=1; next }
+    found && /^###? / { exit }
+    found && /^- / { print }
+  ' "${PDLC_HANDOFF}"
+}
+
+# Get a specific field from the restored checkpoint.
+#
+# Usage: pdlc_session_get_checkpoint_field "Iteration"
+# Output: the field value (e.g., "5") or empty
+pdlc_session_get_checkpoint_field() {
+  local field="$1"
+  local restored
+  restored=$(pdlc_session_restore)
+  if [[ -z "$restored" ]]; then
+    echo ""
+    return 0
+  fi
+  echo "$restored" | awk -F': ' -v key="$field" '$0 ~ "^- " key ": " { print substr($0, length(key)+5); exit }'
+}

--- a/hooks/pdlc-outer-loop.sh
+++ b/hooks/pdlc-outer-loop.sh
@@ -55,6 +55,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/lib/pdlc-state.sh"
 source "${SCRIPT_DIR}/lib/pdlc-director.sh"
+source "${SCRIPT_DIR}/lib/pdlc-session.sh"
 
 # --- Configuration ---
 SPEC_DIR="${PDLC_SPEC_DIR:-}"
@@ -196,6 +197,13 @@ None yet.
 None."
 fi
 
+# --- Restore previous session checkpoint (REQ-SP-005) ---
+SESSION_CONTEXT=$(pdlc_session_restore)
+if [[ -n "${SESSION_CONTEXT}" ]]; then
+  echo "Restored previous session checkpoint:"
+  echo "${SESSION_CONTEXT}"
+fi
+
 # --- Session loop (resume from HANDOFF.md if restarting) ---
 SESSION_COUNT=$(pdlc_get_field "session_count")
 SESSION_COUNT="${SESSION_COUNT:-0}"
@@ -307,6 +315,12 @@ while [[ "${SESSION_COUNT}" -lt "${MAX_SESSIONS}" ]]; do
       echo "  Review accepted for Complete spec — phase set to DONE"
     fi
   fi
+
+  # --- Save session checkpoint (REQ-SP-003) ---
+  pdlc_session_save "${SPEC_DIR}" "${SESSION_COUNT}" "${LIFECYCLE_STATE}" \
+    "${DIRECTOR_ACTION}|${DIRECTOR_MODE}|${DIRECTOR_RATIONALE}" \
+    "session_cost=${SESSION_COST}" \
+    "${CRITIC_VERDICT}"
 
   # --- Circuit breaker: max cost ---
   if (( $(echo "${TOTAL_COST} > ${MAX_COST_USD}" | bc -l 2>/dev/null || echo 0) )); then

--- a/hooks/pdlc-outer-loop.sh
+++ b/hooks/pdlc-outer-loop.sh
@@ -317,9 +317,20 @@ while [[ "${SESSION_COUNT}" -lt "${MAX_SESSIONS}" ]]; do
   fi
 
   # --- Save session checkpoint (REQ-SP-003) ---
-  pdlc_session_save "${SPEC_DIR}" "${SESSION_COUNT}" "${LIFECYCLE_STATE}" \
+  # Determine actor result from git diff (changes vs no changes)
+  local actor_result="no changes"
+  if [[ "${GIT_AVAILABLE}" == "true" ]]; then
+    local diff_stat
+    diff_stat=$(git diff --stat HEAD 2>/dev/null || echo "")
+    if [[ -n "${diff_stat}" ]]; then
+      local files_changed
+      files_changed=$(echo "${diff_stat}" | tail -1 | grep -oE '[0-9]+ file' | grep -oE '[0-9]+' || echo "0")
+      actor_result="success (${files_changed} files changed)"
+    fi
+  fi
+  pdlc_session_save "${SESSION_COUNT}" "${LIFECYCLE_STATE}" \
     "${DIRECTOR_ACTION}|${DIRECTOR_MODE}|${DIRECTOR_RATIONALE}" \
-    "session_cost=${SESSION_COST}" \
+    "${actor_result}" \
     "${CRITIC_VERDICT}"
 
   # --- Circuit breaker: max cost ---

--- a/tests/unit/pdlc-session.bats
+++ b/tests/unit/pdlc-session.bats
@@ -12,6 +12,10 @@ setup() {
   source "${HOOKS_DIR}/lib/pdlc-session.sh"
 }
 
+teardown() {
+  rm -rf "${TEST_WORK_DIR}"
+}
+
 # ──────────────────────────────────────────────────────────
 # REQ-SP-004: pdlc_session_save
 # ──────────────────────────────────────────────────────────
@@ -23,7 +27,7 @@ spec_dir: .claude/specs/feat" "## Current Batch Context
 
 Starting session."
 
-  pdlc_session_save ".claude/specs/feat" "3" "Implementing" \
+  pdlc_session_save "3" "Implementing" \
     "implement|spawn|Heavy work" "success (3 files changed)" "accept"
 
   grep -q "### Session Checkpoint" "${PDLC_HANDOFF}"
@@ -33,7 +37,7 @@ Starting session."
   pdlc_write_handoff "phase: ACTOR
 batch: 1" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "5" "Implementing" \
+  pdlc_session_save "5" "Implementing" \
     "implement|spawn|Work" "success" "accept"
 
   grep -q "Iteration: 5" "${PDLC_HANDOFF}"
@@ -43,7 +47,7 @@ batch: 1" "## Context"
   pdlc_write_handoff "phase: ACTOR
 batch: 1" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "1" "Tasked" \
+  pdlc_session_save "1" "Tasked" \
     "implement|same-session|Start" "pending" "accept"
 
   grep -q "Lifecycle: Tasked" "${PDLC_HANDOFF}"
@@ -57,7 +61,7 @@ batch: 1" "## Context"
   pdlc_write_handoff "phase: ACTOR
 batch: 1" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "2" "Implementing" \
+  pdlc_session_save "2" "Implementing" \
     "implement|spawn|Heavy implementation work" "success" "accept"
 
   grep -q "Director: implement|spawn|Heavy implementation work" "${PDLC_HANDOFF}"
@@ -73,7 +77,7 @@ batch: 1
 batch_1_advocate: PASS
 batch_1_skeptic: PASS_WARN" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+  pdlc_session_save "1" "Implementing" \
     "implement|spawn|Work" "success" "accept"
 
   grep -q "Quality: advocate=PASS, skeptic=PASS_WARN" "${PDLC_HANDOFF}"
@@ -83,7 +87,7 @@ batch_1_skeptic: PASS_WARN" "## Context"
   pdlc_write_handoff "phase: ACTOR
 batch: 1" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+  pdlc_session_save "1" "Implementing" \
     "implement|spawn|Work" "success" "accept"
 
   grep -q "Quality: N/A" "${PDLC_HANDOFF}"
@@ -97,7 +101,7 @@ batch: 1" "## Context"
   pdlc_write_handoff "phase: ACTOR
 batch: 1" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+  pdlc_session_save "1" "Implementing" \
     "implement|spawn|Work" "success (3 files changed)" "accept"
 
   grep -q "Actor: success (3 files changed)" "${PDLC_HANDOFF}"
@@ -107,7 +111,7 @@ batch: 1" "## Context"
   pdlc_write_handoff "phase: ACTOR
 batch: 1" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+  pdlc_session_save "1" "Implementing" \
     "implement|spawn|Work" "success" "retry"
 
   grep -q "Critic: retry" "${PDLC_HANDOFF}"
@@ -117,7 +121,7 @@ batch: 1" "## Context"
   pdlc_write_handoff "phase: ACTOR
 batch: 1" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+  pdlc_session_save "1" "Implementing" \
     "implement|spawn|Work" "success" "accept"
 
   grep -qE "Timestamp: [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z" "${PDLC_HANDOFF}"
@@ -132,7 +136,7 @@ batch: 1" "## Context"
 batch: 1
 spec_dir: .claude/specs/feat" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+  pdlc_session_save "1" "Implementing" \
     "implement|spawn|Work" "success" "accept"
 
   run pdlc_get_field "phase"
@@ -153,7 +157,7 @@ Starting session.
 
 Used TDD approach."
 
-  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+  pdlc_session_save "1" "Implementing" \
     "implement|spawn|Work" "success" "accept"
 
   grep -q "## Current Batch Context" "${PDLC_HANDOFF}"
@@ -166,7 +170,7 @@ Used TDD approach."
   pdlc_write_handoff "phase: ACTOR
 batch: 1" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+  pdlc_session_save "1" "Implementing" \
     "implement|spawn|Work" "success" "accept"
 
   local tmp_count
@@ -178,10 +182,10 @@ batch: 1" "## Context"
   pdlc_write_handoff "phase: ACTOR
 batch: 1" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+  pdlc_session_save "1" "Implementing" \
     "implement|spawn|Work" "success" "accept"
 
-  pdlc_session_save ".claude/specs/feat" "2" "Implementing" \
+  pdlc_session_save "2" "Implementing" \
     "implement|spawn|More work" "success" "accept"
 
   # Should have exactly one checkpoint section
@@ -195,7 +199,7 @@ batch: 1" "## Context"
 }
 
 @test "session_save: no-op if HANDOFF.md does not exist" {
-  run pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+  run pdlc_session_save "1" "Implementing" \
     "implement|spawn|Work" "success" "accept"
 
   [[ "$status" -eq 0 ]]
@@ -322,7 +326,7 @@ batch: 1" "## Context
 
 Starting work."
 
-  pdlc_session_save ".claude/specs/feat" "4" "Implementing" \
+  pdlc_session_save "4" "Implementing" \
     "implement|spawn|TDD cycle" "success (2 files changed)" "accept"
 
   run pdlc_session_restore
@@ -338,11 +342,11 @@ Starting work."
   pdlc_write_handoff "phase: ACTOR
 batch: 1" "## Context"
 
-  pdlc_session_save ".claude/specs/feat" "1" "Tasked" \
+  pdlc_session_save "1" "Tasked" \
     "implement|spawn|First" "success" "accept"
-  pdlc_session_save ".claude/specs/feat" "2" "Implementing" \
+  pdlc_session_save "2" "Implementing" \
     "implement|spawn|Second" "success" "accept"
-  pdlc_session_save ".claude/specs/feat" "3" "Implementing" \
+  pdlc_session_save "3" "Implementing" \
     "implement|spawn|Third" "success" "retry"
 
   run pdlc_session_restore

--- a/tests/unit/pdlc-session.bats
+++ b/tests/unit/pdlc-session.bats
@@ -1,0 +1,354 @@
+#!/usr/bin/env bats
+# tests/unit/pdlc-session.bats — Unit tests for hooks/lib/pdlc-session.sh
+
+load ../helpers/common-setup
+
+setup() {
+  TEST_WORK_DIR="$(mktemp -d)"
+  source "${HOOKS_DIR}/lib/pdlc-state.sh"
+  PDLC_STATE_DIR="${TEST_WORK_DIR}/.pdlc/state"
+  PDLC_HANDOFF="${PDLC_STATE_DIR}/HANDOFF.md"
+  PDLC_MARKER="${PDLC_STATE_DIR}/.compact_marker"
+  source "${HOOKS_DIR}/lib/pdlc-session.sh"
+}
+
+# ──────────────────────────────────────────────────────────
+# REQ-SP-004: pdlc_session_save
+# ──────────────────────────────────────────────────────────
+
+@test "session_save: writes checkpoint section to HANDOFF.md body" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1
+spec_dir: .claude/specs/feat" "## Current Batch Context
+
+Starting session."
+
+  pdlc_session_save ".claude/specs/feat" "3" "Implementing" \
+    "implement|spawn|Heavy work" "success (3 files changed)" "accept"
+
+  grep -q "### Session Checkpoint" "${PDLC_HANDOFF}"
+}
+
+@test "session_save: checkpoint contains iteration number" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "5" "Implementing" \
+    "implement|spawn|Work" "success" "accept"
+
+  grep -q "Iteration: 5" "${PDLC_HANDOFF}"
+}
+
+@test "session_save: checkpoint contains lifecycle state" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "1" "Tasked" \
+    "implement|same-session|Start" "pending" "accept"
+
+  grep -q "Lifecycle: Tasked" "${PDLC_HANDOFF}"
+}
+
+# ──────────────────────────────────────────────────────────
+# REQ-SP-001: Director dispatch decisions persisted
+# ──────────────────────────────────────────────────────────
+
+@test "session_save: checkpoint contains Director decision" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "2" "Implementing" \
+    "implement|spawn|Heavy implementation work" "success" "accept"
+
+  grep -q "Director: implement|spawn|Heavy implementation work" "${PDLC_HANDOFF}"
+}
+
+# ──────────────────────────────────────────────────────────
+# REQ-SP-002: Quality gate results persisted
+# ──────────────────────────────────────────────────────────
+
+@test "session_save: checkpoint contains quality line with advocate/skeptic" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1
+batch_1_advocate: PASS
+batch_1_skeptic: PASS_WARN" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+    "implement|spawn|Work" "success" "accept"
+
+  grep -q "Quality: advocate=PASS, skeptic=PASS_WARN" "${PDLC_HANDOFF}"
+}
+
+@test "session_save: quality line shows N/A when no critic results" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+    "implement|spawn|Work" "success" "accept"
+
+  grep -q "Quality: N/A" "${PDLC_HANDOFF}"
+}
+
+# ──────────────────────────────────────────────────────────
+# REQ-SP-003: Checkpoint contains all required fields
+# ──────────────────────────────────────────────────────────
+
+@test "session_save: checkpoint contains Actor result" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+    "implement|spawn|Work" "success (3 files changed)" "accept"
+
+  grep -q "Actor: success (3 files changed)" "${PDLC_HANDOFF}"
+}
+
+@test "session_save: checkpoint contains Critic verdict" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+    "implement|spawn|Work" "success" "retry"
+
+  grep -q "Critic: retry" "${PDLC_HANDOFF}"
+}
+
+@test "session_save: checkpoint contains timestamp" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+    "implement|spawn|Work" "success" "accept"
+
+  grep -qE "Timestamp: [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z" "${PDLC_HANDOFF}"
+}
+
+# ──────────────────────────────────────────────────────────
+# REQ-SP-004: Atomic writes (no corruption)
+# ──────────────────────────────────────────────────────────
+
+@test "session_save: frontmatter preserved after save" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1
+spec_dir: .claude/specs/feat" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+    "implement|spawn|Work" "success" "accept"
+
+  run pdlc_get_field "phase"
+  [[ "$output" == "ACTOR" ]]
+  run pdlc_get_field "batch"
+  [[ "$output" == "1" ]]
+  run pdlc_get_field "spec_dir"
+  [[ "$output" == ".claude/specs/feat" ]]
+}
+
+@test "session_save: existing body content preserved" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Current Batch Context
+
+Starting session.
+
+## Key Decisions
+
+Used TDD approach."
+
+  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+    "implement|spawn|Work" "success" "accept"
+
+  grep -q "## Current Batch Context" "${PDLC_HANDOFF}"
+  grep -q "Starting session." "${PDLC_HANDOFF}"
+  grep -q "## Key Decisions" "${PDLC_HANDOFF}"
+  grep -q "Used TDD approach." "${PDLC_HANDOFF}"
+}
+
+@test "session_save: no .tmp file left after save" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+    "implement|spawn|Work" "success" "accept"
+
+  local tmp_count
+  tmp_count=$(find "${PDLC_STATE_DIR}" -name "*.tmp*" 2>/dev/null | wc -l | tr -d ' ')
+  [[ "$tmp_count" -eq 0 ]]
+}
+
+@test "session_save: replaces existing checkpoint on re-save" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+    "implement|spawn|Work" "success" "accept"
+
+  pdlc_session_save ".claude/specs/feat" "2" "Implementing" \
+    "implement|spawn|More work" "success" "accept"
+
+  # Should have exactly one checkpoint section
+  local count
+  count=$(grep -c "### Session Checkpoint" "${PDLC_HANDOFF}")
+  [[ "$count" -eq 1 ]]
+  # Should reflect the latest iteration
+  grep -q "Iteration: 2" "${PDLC_HANDOFF}"
+  # Old iteration should be gone
+  ! grep -q "Iteration: 1" "${PDLC_HANDOFF}"
+}
+
+@test "session_save: no-op if HANDOFF.md does not exist" {
+  run pdlc_session_save ".claude/specs/feat" "1" "Implementing" \
+    "implement|spawn|Work" "success" "accept"
+
+  [[ "$status" -eq 0 ]]
+  [[ ! -f "${PDLC_HANDOFF}" ]]
+}
+
+# ──────────────────────────────────────────────────────────
+# REQ-SP-005: pdlc_session_restore
+# ──────────────────────────────────────────────────────────
+
+@test "session_restore: returns checkpoint fields" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context
+
+### Session Checkpoint
+
+- Iteration: 5
+- Lifecycle: Implementing
+- Director: implement|spawn|Heavy work
+- Actor: success (3 files changed)
+- Critic: accept
+- Quality: advocate=PASS, skeptic=PASS
+- Timestamp: 2026-03-17T20:00:00Z"
+
+  run pdlc_session_restore
+  [[ "$status" -eq 0 ]]
+  echo "$output" | grep -q "Iteration: 5"
+  echo "$output" | grep -q "Lifecycle: Implementing"
+  echo "$output" | grep -q "Director: implement|spawn|Heavy work"
+  echo "$output" | grep -q "Actor: success (3 files changed)"
+  echo "$output" | grep -q "Critic: accept"
+  echo "$output" | grep -q "Quality: advocate=PASS, skeptic=PASS"
+  echo "$output" | grep -q "Timestamp: 2026-03-17T20:00:00Z"
+}
+
+@test "session_restore: returns empty when no checkpoint" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context
+
+No checkpoint here."
+
+  run pdlc_session_restore
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+@test "session_restore: returns empty when no HANDOFF.md" {
+  run pdlc_session_restore
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+@test "session_restore: stops at next heading" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context
+
+### Session Checkpoint
+
+- Iteration: 3
+- Lifecycle: Implementing
+
+## Key Decisions
+
+Should not appear."
+
+  run pdlc_session_restore
+  [[ "$status" -eq 0 ]]
+  echo "$output" | grep -q "Iteration: 3"
+  ! echo "$output" | grep -q "Should not appear"
+}
+
+# ──────────────────────────────────────────────────────────
+# REQ-SP-005: pdlc_session_get_checkpoint_field
+# ──────────────────────────────────────────────────────────
+
+@test "session_get_checkpoint_field: returns specific field value" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context
+
+### Session Checkpoint
+
+- Iteration: 7
+- Lifecycle: Complete
+- Director: review|same-session|Final review
+- Actor: success
+- Critic: accept
+- Quality: N/A
+- Timestamp: 2026-03-17T22:00:00Z"
+
+  run pdlc_session_get_checkpoint_field "Iteration"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "7" ]]
+}
+
+@test "session_get_checkpoint_field: returns empty for missing field" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context
+
+### Session Checkpoint
+
+- Iteration: 1"
+
+  run pdlc_session_get_checkpoint_field "Nonexistent"
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+@test "session_get_checkpoint_field: returns empty when no checkpoint" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  run pdlc_session_get_checkpoint_field "Iteration"
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+# ──────────────────────────────────────────────────────────
+# Round-trip: save then restore
+# ──────────────────────────────────────────────────────────
+
+@test "round-trip: save then restore returns same data" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context
+
+Starting work."
+
+  pdlc_session_save ".claude/specs/feat" "4" "Implementing" \
+    "implement|spawn|TDD cycle" "success (2 files changed)" "accept"
+
+  run pdlc_session_restore
+  [[ "$status" -eq 0 ]]
+  echo "$output" | grep -q "Iteration: 4"
+  echo "$output" | grep -q "Lifecycle: Implementing"
+  echo "$output" | grep -q "Director: implement|spawn|TDD cycle"
+  echo "$output" | grep -q "Actor: success (2 files changed)"
+  echo "$output" | grep -q "Critic: accept"
+}
+
+@test "round-trip: multiple saves preserve only latest" {
+  pdlc_write_handoff "phase: ACTOR
+batch: 1" "## Context"
+
+  pdlc_session_save ".claude/specs/feat" "1" "Tasked" \
+    "implement|spawn|First" "success" "accept"
+  pdlc_session_save ".claude/specs/feat" "2" "Implementing" \
+    "implement|spawn|Second" "success" "accept"
+  pdlc_session_save ".claude/specs/feat" "3" "Implementing" \
+    "implement|spawn|Third" "success" "retry"
+
+  run pdlc_session_restore
+  [[ "$status" -eq 0 ]]
+  echo "$output" | grep -q "Iteration: 3"
+  echo "$output" | grep -q "Critic: retry"
+  ! echo "$output" | grep -q "Iteration: 1"
+  ! echo "$output" | grep -q "Iteration: 2"
+}


### PR DESCRIPTION
## Summary

Implemented by **Loki Mode v6.15.0** via OpenSpec adapter — fully autonomous.

- `hooks/lib/pdlc-session.sh` — session checkpoint save/restore
- Outer loop integration — saves checkpoint each iteration, restores on startup  
- Director integration — restored session context in prompt
- `.gitignore` — added `openspec/` and `.loki/`

Loki quality gates: 3/3 PASS, 0 FAIL. 23 new tests.

## Test plan

- [x] 23 new BATS tests (`tests/unit/pdlc-session.bats`)
- [x] Full suite passes

🤖 Generated with [Loki Mode](https://github.com/tseyanlin/loki-mode) + [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session persistence to save and restore workflow progress across runs.
  * Director now displays previous session context on startup to aid resumption.
  * Checkpoints track iteration, lifecycle state, decisions, results, quality, and timestamp.

* **Tests**
  * Added comprehensive unit tests for checkpoint save/restore, edge cases, and atomic write integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->